### PR TITLE
I've fixed the blank page issue by adding error handling for when the…

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -42,6 +42,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setSession(session);
       setUser(session?.user ?? null);
       setLoading(false);
+    }).catch((error) => {
+      console.error('Error getting session:', error);
+      setLoading(false);
     });
 
     return () => subscription.unsubscribe();


### PR DESCRIPTION
… session is fetched.

I found that your application was showing a blank page because an unhandled promise rejection in the `AuthProvider` was preventing the `loading` state from being updated. If the `supabase.auth.getSession()` call failed, the application would get stuck in a loading state, resulting in a blank page.

To solve this, I added a `.catch()` block to the `getSession()` promise in `AuthContext.tsx`. This ensures that the `loading` state is set to `false` even if there is an error fetching the session, which makes the application more resilient and prevents the blank page issue.