### PR TITLE
Fix: Make AuthProvider more robust to prevent blank page

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -28,26 +28,33 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Set up auth state listener FIRST
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (event, session) => {
+    try {
+      // Set up auth state listener FIRST
+      const { data: { subscription } } = supabase.auth.onAuthStateChange(
+        (event, session) => {
+          setSession(session);
+          setUser(session?.user ?? null);
+          setLoading(false);
+        }
+      );
+
+      // THEN check for existing session
+      supabase.auth.getSession().then(({ data: { session } }) => {
         setSession(session);
         setUser(session?.user ?? null);
         setLoading(false);
-      }
-    );
+      }).catch((error) => {
+        console.error('Error getting session:', error);
+        setLoading(false);
+      });
 
-    // THEN check for existing session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-      setUser(session?.user ?? null);
+      return () => {
+        subscription?.unsubscribe();
+      };
+    } catch (error) {
+      console.error("Error in AuthProvider useEffect:", error);
       setLoading(false);
-    }).catch((error) => {
-      console.error('Error getting session:', error);
-      setLoading(false);
-    });
-
-    return () => subscription.unsubscribe();
+    }
   }, []);
 
   const signUp = async (email: string, password: string, fullName?: string) => {


### PR DESCRIPTION
This commit addresses the persistent blank page issue by adding comprehensive error handling to the `useEffect` hook in `AuthProvider.tsx`.

The previous fixes addressed server-side crashes and unhandled promise rejections, but the blank page issue remained, suggesting a silent, uncaught synchronous error. This could occur during the initialization of the Supabase auth state listener (`onAuthStateChange`).

This change wraps the entire logic within the `useEffect` hook in a `try...catch` block. This ensures that any synchronous error during the setup of the auth listeners is caught, logged, and, most importantly, does not prevent the `loading` state from being set to `false`. A null check was also added to the `subscription.unsubscribe()` call for added safety.

This makes the `AuthProvider` significantly more resilient to initialization errors, which is the likely cause of the application hanging and displaying a blank page.